### PR TITLE
chore(ci): Enhance PA label automation for closed pull requests

### DIFF
--- a/.github/workflows/pa-labels.yml
+++ b/.github/workflows/pa-labels.yml
@@ -2,7 +2,7 @@ name: PA Label Automation
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, review_requested, review_request_removed]
+    types: [opened, reopened, ready_for_review, review_requested, review_request_removed, closed]
   pull_request_review:
     types: [submitted, dismissed]
 
@@ -21,6 +21,47 @@ jobs:
             const repo  = context.repo.repo;
             const prNumber = context.payload.pull_request?.number
                           ?? context.payload.review?.pull_request?.number;
+
+            if (context.payload.action === 'closed') {
+              const merged = context.payload.pull_request?.merged;
+              const PA_LABELS = [
+                'PA: Pending All Reviewers',
+                'PA: Pending One Reviewer',
+                'PA: Awaiting Author',
+                'PA: Awaiting CI',
+                'PA: Reviewer Assigned',
+                'PA: Under Review',
+                'PA: Second Opinion Needed',
+                'PR: Approved',
+                'PR: Changes Requested',
+                'PR: Ready For Review',
+              ];
+
+              const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+                owner, repo, issue_number: prNumber,
+              });
+
+              for (const label of currentLabels) {
+                if (PA_LABELS.includes(label.name)) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner, repo, issue_number: prNumber, name: label.name,
+                    });
+                  } catch (_) {}
+                }
+              }
+
+              if (merged) {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: prNumber, labels: ['PR: Merged'],
+                });
+              } else {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: prNumber, labels: ['PR: Closed Without Merge'],
+                });
+              }
+              return;
+            }
 
             const { data: pr } = await github.rest.pulls.get({
               owner, repo, pull_number: prNumber,
@@ -60,8 +101,8 @@ jobs:
             const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
               owner, repo, issue_number: prNumber,
             });
-            const current = new Set(currentLabels.map(l => l.name));
 
+            const current = new Set(currentLabels.map(l => l.name));
             let add    = new Set();
             let remove = new Set(PA_LABELS.filter(l => current.has(l)));
 


### PR DESCRIPTION
## Summary

Updated the pull request workflow to handle closed events and manage labels accordingly.

Closes #<!-- issue number -->

---

### Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Tests
- [x] Chore / tooling / CI

---

### Changes

<!-- Brief bullet list of what changed and why -->

-

---

### Testing

<!-- How did you verify this works? -->

```bash
pytest tests/
```

---

### Breaking Changes

<!-- If this is a breaking change, describe the migration path -->

N/A

---

### Checklist

- [ ] Code follows project style (PEP 8, type hints, docstrings)
- [ ] Pre-commit hooks pass locally (`pre-commit run --all-files`)
- [x] Tests added / updated where relevant
- [x] All existing tests pass
- [x] Documentation updated where necessary
- [x] No new warnings or type errors introduced



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation to improve pull request labeling workflow when PRs are closed, with enhanced handling to distinguish between merged and unmerged states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->